### PR TITLE
Fix Issue #57

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -173,7 +173,7 @@ header {
   padding: 8px;
   position: fixed;
   right: 18px;
-  bottom: 10px;
+  bottom: 4px;
   z-index: 1;
   color: rgb(27, 27, 27);
 }


### PR DESCRIPTION
Fixed the clear button's weird position by updating its positioning (10px to 4px). It doesn't affect the desktop website and the clear button is inline with the placeholder text on the mobile website.